### PR TITLE
Moved /usr/local/lib to the front of the library search path

### DIFF
--- a/LabJackU6Plugin.xcodeproj/project.pbxproj
+++ b/LabJackU6Plugin.xcodeproj/project.pbxproj
@@ -311,8 +311,8 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
 					/usr/local/lib,
+					"$(inherited)",
 				);
 				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.Glickfeld-And-Hull-Laboratories.LabJackU6-Plug-in";


### PR DESCRIPTION
This resolves a build failure with the current MWorks nightly build.